### PR TITLE
Chore/athena smoke sqls

### DIFF
--- a/infra/sql/athena_count.sql
+++ b/infra/sql/athena_count.sql
@@ -1,0 +1,1 @@
+SELECT count(*) AS cnt FROM events_parquet;

--- a/infra/sql/athena_create_db.sql
+++ b/infra/sql/athena_create_db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE IF NOT EXISTS stormevents;

--- a/infra/sql/athena_create_table.sql
+++ b/infra/sql/athena_create_table.sql
@@ -1,20 +1,19 @@
-﻿CREATE DATABASE IF NOT EXISTS stormevents;
 CREATE EXTERNAL TABLE IF NOT EXISTS stormevents.events_parquet (
-  event_id string,
-  state string,
-  event_type string,
-  episode_id string,
-  cz_name string,
-  begin_date_time string,
-  end_date_time string,
-  injuries_direct int,
-  deaths_direct int,
-  damage_property string,
-  magnitude double,
-  latitude double,
-  longitude double
+  event_id           string,
+  state              string,
+  event_type         string,
+  episode_id         string,
+  cz_name            string,
+  begin_date_time    string,
+  end_date_time      string,
+  injuries_direct    int,
+  deaths_direct      int,
+  damage_property    string,
+  magnitude          double,
+  latitude           double,
+  longitude          double
 )
 PARTITIONED BY (year int, event_type_part string)
 STORED AS PARQUET
-LOCATION 's3://YOUR-BUCKET/path/to/stormevents/'
+LOCATION 's3://stormevents-586639910153-us-east-2/data/stormevents/'
 TBLPROPERTIES ('parquet.compression'='SNAPPY');

--- a/infra/sql/athena_create_table.sql
+++ b/infra/sql/athena_create_table.sql
@@ -1,0 +1,20 @@
+﻿CREATE DATABASE IF NOT EXISTS stormevents;
+CREATE EXTERNAL TABLE IF NOT EXISTS stormevents.events_parquet (
+  event_id string,
+  state string,
+  event_type string,
+  episode_id string,
+  cz_name string,
+  begin_date_time string,
+  end_date_time string,
+  injuries_direct int,
+  deaths_direct int,
+  damage_property string,
+  magnitude double,
+  latitude double,
+  longitude double
+)
+PARTITIONED BY (year int, event_type_part string)
+STORED AS PARQUET
+LOCATION 's3://YOUR-BUCKET/path/to/stormevents/'
+TBLPROPERTIES ('parquet.compression'='SNAPPY');

--- a/infra/sql/athena_describe.sql
+++ b/infra/sql/athena_describe.sql
@@ -1,0 +1,1 @@
+DESCRIBE events_parquet;

--- a/infra/sql/athena_repair_partitions.sql
+++ b/infra/sql/athena_repair_partitions.sql
@@ -1,1 +1,1 @@
-﻿MSCK REPAIR TABLE stormevents.events_parquet;
+MSCK REPAIR TABLE stormevents.events_parquet;

--- a/infra/sql/athena_repair_partitions.sql
+++ b/infra/sql/athena_repair_partitions.sql
@@ -1,0 +1,1 @@
+﻿MSCK REPAIR TABLE stormevents.events_parquet;

--- a/infra/sql/athena_select5.sql
+++ b/infra/sql/athena_select5.sql
@@ -1,0 +1,1 @@
+SELECT event_id,state,event_type,magnitude,latitude,longitude FROM events_parquet LIMIT 5;

--- a/infra/sql/athena_show_columns.sql
+++ b/infra/sql/athena_show_columns.sql
@@ -1,0 +1,1 @@
+SHOW COLUMNS FROM stormevents.events_parquet;

--- a/infra/sql/athena_show_create.sql
+++ b/infra/sql/athena_show_create.sql
@@ -1,0 +1,1 @@
+SHOW CREATE TABLE stormevents.events_parquet;

--- a/scripts/run_athena_sql.py
+++ b/scripts/run_athena_sql.py
@@ -1,0 +1,32 @@
+﻿import os, sys, time, boto3
+
+def run_athena(sql_path: str, database: str = "stormevents") -> None:
+    region = os.getenv("AWS_REGION", "us-east-2")
+    output = os.getenv("ATHENA_OUTPUT", "s3://YOUR-BUCKET/athena-output/")
+
+    athena = boto3.client("athena", region_name=region)
+    with open(sql_path, "r", encoding="utf-8") as f:
+        sql = f.read()
+
+    q = athena.start_query_execution(
+        QueryString=sql,
+        QueryExecutionContext={"Database": database},
+        ResultConfiguration={"OutputLocation": output},
+    )
+    qid = q["QueryExecutionId"]
+    print(f"Started Athena query: {qid}")
+
+    while True:
+        res = athena.get_query_execution(QueryExecutionId=qid)
+        s = res["QueryExecution"]["Status"]["State"]
+        if s in {"SUCCEEDED", "FAILED", "CANCELLED"}:
+            print("Status:", s)
+            if s != "SUCCEEDED":
+                reason = res["QueryExecution"]["Status"].get("StateChangeReason", "")
+                print("Reason:", reason)
+            break
+        time.sleep(2)
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else "infra/sql/athena_create_table.sql"
+    run_athena(path)

--- a/scripts/run_athena_sql.py
+++ b/scripts/run_athena_sql.py
@@ -1,4 +1,8 @@
-﻿import os, sys, time, boto3
+﻿import os
+import sys
+import time
+import boto3
+
 
 def run_athena(sql_path: str, database: str = "stormevents") -> None:
     region = os.getenv("AWS_REGION", "us-east-2")
@@ -26,6 +30,7 @@ def run_athena(sql_path: str, database: str = "stormevents") -> None:
                 print("Reason:", reason)
             break
         time.sleep(2)
+
 
 if __name__ == "__main__":
     path = sys.argv[1] if len(sys.argv) > 1 else "infra/sql/athena_create_table.sql"


### PR DESCRIPTION
## Summary
Add Athena “smoke” SQLs and a tiny runner to verify DB/table/partitions:
- `infra/sql/athena_create_db.sql`
- `infra/sql/athena_create_table.sql` (already used)
- `infra/sql/athena_repair_partitions.sql`
- `infra/sql/athena_show_create.sql`
- `infra/sql/athena_show_columns.sql`
- `infra/sql/athena_describe.sql`
- `infra/sql/athena_count.sql`
- `infra/sql/athena_select5.sql`
- `scripts/run_athena_sql.py`

## How to test
1) Set env: `AWS_PROFILE=stormevents-dev`, `AWS_REGION=us-east-2`, `ATHENA_OUTPUT=s3://<athena-output-bucket>/athena-output/`
2) Run:
   - `python scripts/run_athena_sql.py infra/sql/athena_show_columns.sql stormevents`
   - `python scripts/run_athena_sql.py infra/sql/athena_count.sql stormevents`
   - (optionally) `python scripts/run_athena_sql.py infra/sql/athena_select5.sql stormevents`
All should return `Status: SUCCEEDED`.

## Notes
- SQL files are UTF-8 without BOM (Athena-friendly).
- No secrets are committed; runner uses standard AWS creds/ENV.

